### PR TITLE
fix(lib): disable debug info to work-around a compiler bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ git = "https://github.com/japaric/stats.rs"
 
 [dependencies.time]
 git = "https://github.com/rust-lang/time"
+
+[profile.dev]
+debug = false


### PR DESCRIPTION
See rust-lang/rust#17257
