### PR TITLE
Rustup: Update dependencies and make structs public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ git = "https://github.com/rust-lang/log"
 git = "https://github.com/rust-lang/rustc-serialize"
 
 [dependencies.simplot]
-git = "https://github.com/brianw1/simplot.rs"
-branch = "brianw1/master"
+git = "https://github.com/japaric/simplot.rs"
 
 [dependencies.space]
 git = "https://github.com/japaric/space.rs"
 
 [dependencies.stats]
-git = "https://github.com/faern/stats.rs"
+git = "https://github.com/japaric/stats.rs"
+branch = "no-simd"
 
 [dependencies.time]
 git = "https://github.com/rust-lang/time"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![deny(missing_docs)]
 #![feature(test)]
-#![feature(iter_cmp)]
 
 #[macro_use]
 extern crate log;
@@ -395,17 +394,22 @@ impl Plotting {
     }
 }
 
+/// A confidence interval representation
 #[derive(Clone, Copy, PartialEq, RustcDecodable, RustcEncodable)]
-struct ConfidenceInterval {
+pub struct ConfidenceInterval {
     confidence_level: f64,
     lower_bound: f64,
     upper_bound: f64,
 }
 
+///
 #[derive(Clone, Copy, PartialEq, RustcDecodable, RustcEncodable)]
-struct Estimate {
+pub struct Estimate {
+    /// The confidence interval for this estimate
     pub confidence_interval: ConfidenceInterval,
+    ///
     pub point_estimate: f64,
+    /// The standard error of this estimate
     pub standard_error: f64,
 }
 

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -44,7 +44,7 @@ pub fn pdf(data: Data<f64, f64>, labeled_sample: LabeledSample<f64>, id: &str) {
 
     let (x_scale, prefix) = scale_time(labeled_sample.max());
 
-    let &max_iters = data.x().as_slice().iter().max_by(|&&iters| iters as u64).unwrap();
+    let &max_iters = data.x().as_slice().iter().max_by_key(|&&iters| iters as u64).unwrap();
     let exponent = (max_iters.log10() / 3.).floor() as i32 * 3;
     let y_scale = 10f64.powi(-exponent);
 


### PR DESCRIPTION
I pointed some dependencies back to your repos since they should work now.

Do you agree with making the structs public? I'm mostly guessing to make stuff build again. The sound like they could be public. Note that I didn't provide the best docs yet. Please come with suggestions on what to write or say that it's OK to leave as is. Linter options force us to provide docs.

@japaric 