### PR TITLE
settle on API for release

### DIFF
--- a/benches/iter_with_large_drop.rs
+++ b/benches/iter_with_large_drop.rs
@@ -7,6 +7,7 @@ const SIZE: usize = 1024 * 1024;
 #[test]
 fn alloc() {
     Criterion::default()
-        .bench("alloc", |b| b.iter_with_large_drop(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>()));
-
+        .bench_function("alloc", |b| {
+            b.iter_with_large_drop(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>())
+        });
 }

--- a/benches/iter_with_large_setup.rs
+++ b/benches/iter_with_large_setup.rs
@@ -9,7 +9,7 @@ const SIZE: usize = 1024 * 1024;
 #[test]
 fn dealloc() {
     Criterion::default()
-        .bench("large_dealloc", |b| {
+        .bench_function("large_dealloc", |b| {
             b.iter_with_large_setup(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>(),
                                     |v| mem::drop(v));
         });

--- a/benches/iter_with_setup.rs
+++ b/benches/iter_with_setup.rs
@@ -9,6 +9,7 @@ const SIZE: usize = 1024 * 1024;
 #[test]
 fn dealloc() {
     Criterion::default()
-        .bench("dealloc", |b| b.iter_with_setup(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>(),
-                                                |v| mem::drop(v)));
+        .bench_function("dealloc", |b| {
+            b.iter_with_setup(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>(), |v| mem::drop(v))
+        });
 }

--- a/benches/no-plots.rs
+++ b/benches/no-plots.rs
@@ -7,7 +7,7 @@ use walkdir::WalkDir;
 
 #[test]
 fn no_plots() {
-    Criterion::default().without_plots().bench("dummy", |b| b.iter(|| {}));
+    Criterion::default().without_plots().bench_function("dummy", |b| b.iter(|| {}));
 
     assert!(!WalkDir::new(".criterion/dummy").into_iter().any(|entry| {
         entry.unwrap().path().extension().and_then(|ext| ext.to_str()) == Some("svg")

--- a/benches/with_inputs.rs
+++ b/benches/with_inputs.rs
@@ -9,7 +9,7 @@ use criterion::Criterion;
 fn from_elem() {
     static KB: usize = 1024;
 
-    let can_plot = Criterion::default().bench_with_inputs("from_elem", |b, &&size| {
+    let can_plot = Criterion::default().bench_function_over_inputs("from_elem", |b, &&size| {
         b.iter(|| iter::repeat(0u8).take(size).collect::<Vec<_>>());
     }, &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB]).can_plot();
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -41,7 +41,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
 ///         b.iter(|| {});
 ///     }
 ///
-///     ::criterion::Criterion::default().bench("routine", routine);
+///     ::criterion::Criterion::default().bench_function("routine", routine);
 /// }
 /// ```
 fn expand_meta_criterion(
@@ -62,10 +62,10 @@ fn expand_meta_criterion(
             let criterion_path = vec!(crate_ident, struct_ident, method_ident);
             let default_criterion = cx.expr_call_global(span, criterion_path, vec!());
 
-            // `.bench("routine", routine);`
+            // `.bench_function("routine", routine);`
             let routine_str = cx.expr_str(span, routine.ident.name.as_str());
             let routine_ident = cx.expr_ident(span, routine.ident);
-            let bench_ident = token::str_to_ident("bench");
+            let bench_ident = token::str_to_ident("bench_function");
             let bench_call = cx.expr_method_call(span, default_criterion, bench_ident,
                                                  vec!(routine_str, routine_ident));
             let bench_call = cx.stmt_expr(bench_call);

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -60,7 +60,7 @@ pub fn functions<I>(id: &str,
     summarize(id, criterion);
 }
 
-pub fn function_with_inputs<I, F>(
+pub fn function_over_inputs<I, F>(
     id: &str,
     mut f: F,
     inputs: I,
@@ -85,7 +85,7 @@ pub fn program(id: &str, prog: &mut Command, criterion: &Criterion) {
     println!("");
 }
 
-pub fn program_with_inputs<I, F>(
+pub fn program_over_inputs<I, F>(
     id: &str,
     mut prog: F,
     inputs: I,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,9 +504,9 @@ impl Criterion {
     ///     // Teardown (free resources)
     /// }
     ///
-    /// Criterion::default().bench("routine", routine);
+    /// Criterion::default().bench_function("routine", routine);
     /// ```
-    pub fn bench<F>(&mut self, id: &str, f: F) -> &mut Criterion where
+    pub fn bench_function<F>(&mut self, id: &str, f: F) -> &mut Criterion where
         F: FnMut(&mut Bencher),
     {
         analysis::function(id, f, self);
@@ -560,11 +560,12 @@ impl Criterion {
     /// ```rust,no_run
     /// use self::criterion::{Bencher, Criterion};
     ///
-    /// Criterion::default().bench_with_inputs("from_elem", |b: &mut Bencher, &&size: &&usize| {
-    ///     b.iter(|| vec![0u8; size]);
-    /// }, &[1024, 2048, 4096]);
+    /// Criterion::default()
+    ///     .bench_function_over_inputs("from_elem", |b: &mut Bencher, &&size: &&usize| {
+    ///         b.iter(|| vec![0u8; size]);
+    ///     }, &[1024, 2048, 4096]);
     /// ```
-    pub fn bench_with_inputs<I, F>(
+    pub fn bench_function_over_inputs<I, F>(
         &mut self,
         id: &str,
         f: F,
@@ -626,7 +627,7 @@ impl Criterion {
     ///
     /// This is a convenience method to execute several related benchmarks. Each benchmark will
     /// receive the id: `${id}/${input}`.
-    pub fn bench_program_with_inputs<I, F>(
+    pub fn bench_program_over_inputs<I, F>(
         &mut self,
         id: &str,
         program: F,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,7 @@ impl Criterion {
         I::Item: fmt::Display,
         F: FnMut(&mut Bencher, &I::Item),
     {
-        analysis::function_with_inputs(id, f, inputs, self);
+        analysis::function_over_inputs(id, f, inputs, self);
 
         self
     }
@@ -637,7 +637,7 @@ impl Criterion {
         I: IntoIterator,
         I::Item: fmt::Display,
     {
-        analysis::program_with_inputs(id, program, inputs, self);
+        analysis::program_over_inputs(id, program, inputs, self);
 
         self
     }


### PR DESCRIPTION
[breaking-change] the following functions have been renamed:

- `Criterion::bench` -> `Criterion::bench_function`
- `Criterion::bench_with_inputs` -> `Criterion::bench_function_over_inputs`
- `Criterion::bench_program_with_inputs` -> `Criterion::bench_program_over_inputs`

---

r? @faern 