### PR TITLE
Add clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,11 @@ before_script:
 
 install:
   - sh ci/install.sh
+  - export PATH=$HOME/cargo-clippy/target/release:$PATH
 
 script:
   - cargo build
+  - cargo clippy
   - cargo test
   - cargo bench -- --test --nocapture
   - cargo doc

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,5 +1,12 @@
 set -ex
 
+oldpath=$(pwd)
+cd $HOME
+git clone https://github.com/arcnmx/cargo-clippy
+cd $HOME/cargo-clippy
+cargo build --release
+cd $oldpath
+
 if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$GNUPLOT" = "yes" ]; then
   brew install gnuplot
 fi

--- a/src/analysis/compare.rs
+++ b/src/analysis/compare.rs
@@ -125,7 +125,7 @@ fn estimates(
         [a, b]
     };
     let distributions: Distributions =
-        [Mean, Median].iter().map(|&x| x).zip(distributions.into_iter()).collect();
+        [Mean, Median].iter().cloned().zip(distributions.into_iter()).collect();
     let estimates = Estimate::new(&distributions, &points, cl);
 
     report::rel(&estimates);
@@ -143,7 +143,7 @@ fn estimates(
     }
 
     let mut regressed = vec!();
-    for (&statistic, estimate) in estimates.iter() {
+    for (&statistic, estimate) in &estimates {
         let result = compare_to_threshold(estimate, threshold);
 
         let p = estimate.point_estimate;

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -20,7 +20,7 @@ macro_rules! elapsed {
     ($msg:expr, $block:expr) => ({
         let start = ::std::time::Instant::now();
         let out = $block;
-        let ref elapsed = start.elapsed();
+        let elapsed = &start.elapsed();
 
         info!("{} took {}", $msg, format::time(::DurationExt::to_nanos(elapsed) as f64));
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -74,10 +74,10 @@ pub fn save<D, P>(data: &D, path: &P) where
 
         let mut buf = String::new();
         {
-            let ref mut encoder = Encoder::new_pretty(&mut buf);
+            let encoder = &mut Encoder::new_pretty(&mut buf);
             data.encode(encoder).unwrap();
         }
-        File::create(path).unwrap().write_all(buf.as_bytes()).ok().expect("Couldn't save data")
+        File::create(path).unwrap().write_all(buf.as_bytes()).expect("Couldn't save data")
     }
 
     save_(data, path.as_ref())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl<I> Fun<I> where I: fmt::Display {
         where F: FnMut(&mut Bencher, &I) + 'static
     {
         Fun {
-            n: name.to_string(),
+            n: name.to_owned(),
             f: Box::new(f),
         }
     }

--- a/src/plot/both.rs
+++ b/src/plot/both.rs
@@ -30,7 +30,7 @@ pub fn regression(
     let x_scale = 10f64.powi(-exponent);
 
     let x_label = if exponent == 0 {
-        "Iterations".to_string()
+        "Iterations".to_owned()
     } else {
         format!("Iterations (x 10^{})", exponent)
     };
@@ -51,7 +51,7 @@ pub fn regression(
         set(Font(DEFAULT_FONT)).
         set(Output(path)).
         set(SIZE).
-        set(Title(id.to_string())).
+        set(Title(id.to_owned())).
         configure(Axis::BottomX, |a| a.
             configure(Grid::Major, |g| g.
                 show()).
@@ -119,7 +119,7 @@ pub fn pdfs(base_avg_times: &Sample<f64>, avg_times: &Sample<f64>, id: &str) {
         set(Font(DEFAULT_FONT)).
         set(Output(path)).
         set(SIZE).
-        set(Title(id.to_string())).
+        set(Title(id.to_owned())).
         configure(Axis::BottomX, |a| a.
             set(Label(format!("Average time ({}s)", prefix))).
             set(ScaleFactor(x_scale))).

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -49,7 +49,7 @@ pub fn pdf(data: Data<f64, f64>, labeled_sample: LabeledSample<f64>, id: &str) {
     let y_scale = 10f64.powi(-exponent);
 
     let y_label = if exponent == 0 {
-        "Iterations".to_string()
+        "Iterations".to_owned()
     } else {
         format!("Iterations (x 10^{})", exponent)
     };
@@ -66,7 +66,7 @@ pub fn pdf(data: Data<f64, f64>, labeled_sample: LabeledSample<f64>, id: &str) {
         set(Font(DEFAULT_FONT)).
         set(Output(path)).
         set(SIZE).
-        set(Title(id.to_string())).
+        set(Title(id.to_owned())).
         configure(Axis::BottomX, |a| a.
             set(Label(format!("Average time ({}s)", prefix))).
             set(Range::Limits(xs_.min() * x_scale, xs_.max() * x_scale)).
@@ -201,7 +201,7 @@ pub fn regression(
     let x_scale = 10f64.powi(-exponent);
 
     let x_label = if exponent == 0 {
-        "Iterations".to_string()
+        "Iterations".to_owned()
     } else {
         format!("Iterations (x 10^{})", exponent)
     };
@@ -215,7 +215,7 @@ pub fn regression(
         set(Font(DEFAULT_FONT)).
         set(Output(path)).
         set(SIZE).
-        set(Title(id.to_string())).
+        set(Title(id.to_owned())).
         configure(Key, |k| k.
             set(Justification::Left).
             set(Order::SampleText).
@@ -519,7 +519,7 @@ pub fn summarize(id: &str) {
     let contents: Vec<_> = fs::ls(&dir).map(|e| e.unwrap().path()).collect();
 
     // XXX Plot both summaries?
-    for &sample in ["new", "base"].iter() {
+    for &sample in &["new", "base"] {
         let mut benches = contents.iter().filter_map(|entry| {
             if entry.is_dir() && entry.file_name().and_then(|s| s.to_str()) != Some("summary") {
                 let label = entry.file_name().unwrap().to_str().unwrap();
@@ -613,7 +613,7 @@ pub fn summarize(id: &str) {
                     set(Font(DEFAULT_FONT)).
                     set(Output(dir.join(&format!("summary/{}/{}s.svg", sample, statistic)))).
                     set(SIZE).
-                    set(Title(format!("{}", id))).
+                    set(Title(id.to_owned())).
                     configure(Axis::BottomX, |a| a.
                         configure(Grid::Major, |g| g.
                             show()).
@@ -834,7 +834,7 @@ pub fn summarize(id: &str) {
                             labels: benches.iter().map(|&(label, _, _, _)| label),
                         })).
                         plot(Points {
-                            x: medians.iter().map(|&median| median),
+                            x: medians.iter().cloned(),
                             y: tics(),
                         }, |c| c.
                         set(Color::Black).

--- a/src/program.rs
+++ b/src/program.rs
@@ -84,7 +84,7 @@ impl Routine for Program {
             let msg = self.recv();
             let msg = msg.trim();
 
-            let elapsed: u64 = msg.parse().ok().expect("Couldn't parse program output");
+            let elapsed: u64 = msg.parse().expect("Couldn't parse program output");
             elapsed as f64
         }).collect()
     }

--- a/src/routine.rs
+++ b/src/routine.rs
@@ -31,7 +31,7 @@ pub trait Routine {
 
         let m_ns = total_runs as f64 * d as f64 * met;
         println!("> Collecting {} samples in estimated {}", n, format::time(m_ns));
-        let m_elapsed = self.bench(m_iters.iter().map(|&x| x));
+        let m_elapsed = self.bench(m_iters.iter().cloned());
 
         let m_iters_f: Vec<f64> = m_iters.iter().map(|&x| x as f64).collect();
 


### PR DESCRIPTION
- Add `clippy` to the list of dependencies.
- Add a `lint` feature that enables `clippy` for now.
- Appease `clippy`'s lints.