### PR TITLE
remove stable `time2` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![deny(missing_docs)]
 #![feature(test)]
-#![feature(time2)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Since that feature is stabilized, we no longer need the feature gate.