### PR TITLE
Fix compile errors in macros, allowing tests to be run successfully.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -6,18 +6,18 @@ extern crate rustc_plugin;
 extern crate syntax;
 
 use rustc_plugin::registry::Registry;
-use syntax::ast::{DUMMY_NODE_ID, DeclKind, Item, ItemKind, MetaItem, StmtKind, self};
+use syntax::ast::{Item, ItemKind, MetaItem, Ident, self};
 use syntax::codemap::{Span, self};
 use syntax::ext::base::{ExtCtxt, MultiModifier, Annotatable};
 use syntax::ext::build::AstBuilder;
-use syntax::parse::token;
 use syntax::ptr::P;
+use syntax::symbol::Symbol;
 
 #[doc(hidden)]
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
     reg.register_syntax_extension(
-        token::intern("criterion"),
+        Symbol::intern("criterion"),
         MultiModifier(Box::new(expand_meta_criterion)));
 }
 
@@ -54,26 +54,25 @@ fn expand_meta_criterion(
         if let ItemKind::Fn(..) = item.node {
             // Copy original function without attributes
             let routine = P(Item { attrs: Vec::new(), .. (*item).clone() });
-
+            
             // `::criterion::Criterion::default()`
-            let crate_ident = token::str_to_ident("criterion");
-            let struct_ident = token::str_to_ident("Criterion");
-            let method_ident = token::str_to_ident("default");
+            let crate_ident = Ident::from_str("criterion");
+            let struct_ident = Ident::from_str("Criterion");
+            let method_ident = Ident::from_str("default");
             let criterion_path = vec!(crate_ident, struct_ident, method_ident);
             let default_criterion = cx.expr_call_global(span, criterion_path, vec!());
 
             // `.bench_function("routine", routine);`
-            let routine_str = cx.expr_str(span, routine.ident.name.as_str());
+            let routine_str = cx.expr_str(span, routine.ident.name);
             let routine_ident = cx.expr_ident(span, routine.ident);
-            let bench_ident = token::str_to_ident("bench_function");
+            let bench_ident = Ident::from_str("bench_function");
             let bench_call = cx.expr_method_call(span, default_criterion, bench_ident,
                                                  vec!(routine_str, routine_ident));
-            let bench_call = cx.stmt_expr(bench_call);
+            let bench_call = cx.stmt_expr(bench_call).add_trailing_semicolon();
 
             // Wrap original function + bench call in a test function
-            let fn_decl = P(codemap::respan(span, DeclKind::Item(routine)));
-            let inner_fn = codemap::respan(span, StmtKind::Decl(fn_decl, DUMMY_NODE_ID));
-            let body = cx.block(span, vec!(inner_fn, bench_call), None);
+            let fn_decl = cx.stmt_item(span, routine);
+            let body = cx.block(span, vec!(fn_decl, bench_call));
             let nil = P(ast::Ty {
                 id: ast::DUMMY_NODE_ID,
                 node: ast::TyKind::Tup(vec![]),
@@ -84,7 +83,7 @@ fn expand_meta_criterion(
             // Add the `#[test]` attribute to existing attributes
             let mut attrs = item.attrs.clone();
             attrs.
-                push(cx.attribute(span, cx.meta_word(span, token::intern_and_get_ident("test"))));
+                push(cx.attribute(span, cx.meta_word(span, Symbol::gensym("test"))));
 
             Annotatable::Item(P(Item { attrs: attrs, .. (*test).clone() }))
         } else {


### PR DESCRIPTION
With this change and https://github.com/japaric/simplot.rs/pull/47, all three criterion crates build and complete all tests on the latest Nightly build (at least on my computer. May need some more work to make Travis/Appveryor happy).