### PR TITLE
Replace floaty dependency with num-traits 

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -43,7 +43,7 @@ pub fn summarize(id: &str, criterion: &Criterion) {
 pub fn function<F>(id: &str, f: F, criterion: &Criterion) where F: FnMut(&mut Bencher) {
     common(id, &mut Function(f), criterion);
 
-    println!("");
+    println!();
 }
 
 pub fn functions<I>(id: &str,
@@ -82,7 +82,7 @@ pub fn function_over_inputs<I, F>(
 pub fn program(id: &str, prog: &mut Command, criterion: &Criterion) {
     common(id, &mut Program::spawn(prog), criterion);
 
-    println!("");
+    println!();
 }
 
 pub fn program_over_inputs<I, F>(

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 cast = "0.1.0"
-floaty = "0.1.0"
+num-traits = "0.1.41"
 num_cpus = "0.2.10"
 rand = "0.3.13"
 thread-scoped = "1.0.1"

--- a/stats/src/bivariate/mod.rs
+++ b/stats/src/bivariate/mod.rs
@@ -8,7 +8,7 @@ pub mod regression;
 use std::ptr::Unique;
 use std::{cmp, mem};
 
-use floaty::Floaty;
+use ::float::Float;
 use num_cpus;
 use thread_scoped as thread;
 
@@ -53,7 +53,7 @@ impl<'a, X, Y> Data<'a, X, Y> {
     }
 }
 
-impl<'a, X, Y> Data<'a, X, Y> where X: Floaty, Y: Floaty {
+impl<'a, X, Y> Data<'a, X, Y> where X: Float, Y: Float {
     /// Creates a new data set from two existing slices
     pub fn new(xs: &'a [X], ys: &'a [Y]) -> Data<'a, X, Y> {
         assert!(

--- a/stats/src/bivariate/regression.rs
+++ b/stats/src/bivariate/regression.rs
@@ -1,14 +1,14 @@
 //! Regression analysis
 
-use floaty::Floaty;
+use ::float::Float;
 
 use bivariate::Data;
 
 /// A straight line that passes through the origin `y = m * x`
 #[derive(Clone, Copy)]
-pub struct Slope<A>(pub A) where A: Floaty;
+pub struct Slope<A>(pub A) where A: Float;
 
-impl<A> Slope<A> where A: Floaty {
+impl<A> Slope<A> where A: Float {
     /// Fits the data to a straight line that passes through the origin using ordinary least
     /// squares
     ///
@@ -50,14 +50,14 @@ impl<A> Slope<A> where A: Floaty {
 
 /// A straight line `y = m * x + b`
 #[derive(Clone, Copy)]
-pub struct StraightLine<A> where A: Floaty {
+pub struct StraightLine<A> where A: Float {
     /// The y-intercept of the line
     pub intercept: A,
     /// The slope of the line
     pub slope: A,
 }
 
-impl<A> StraightLine<A> where A: Floaty {
+impl<A> StraightLine<A> where A: Float {
     /// Fits the data to a straight line using ordinary least squares
     ///
     /// - Time: `O(length)`

--- a/stats/src/bivariate/resamples.rs
+++ b/stats/src/bivariate/resamples.rs
@@ -1,10 +1,10 @@
 use rand::distributions::{IndependentSample, Range};
 use rand::{Rng, XorShiftRng};
-use floaty::Floaty;
+use ::float::Float;
 
 use bivariate::Data;
 
-pub struct Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
+pub struct Resamples<'a, X, Y> where X: 'a + Float, Y: 'a + Float {
     range: Range<usize>,
     rng: XorShiftRng,
     data: (&'a [X], &'a [Y]),
@@ -12,7 +12,7 @@ pub struct Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
 }
 
 #[cfg_attr(clippy, allow(should_implement_trait))]
-impl<'a, X, Y> Resamples<'a, X, Y> where X: 'a + Floaty, Y: 'a + Floaty {
+impl<'a, X, Y> Resamples<'a, X, Y> where X: 'a + Float, Y: 'a + Float {
     pub fn new(data: Data<'a, X, Y>) -> Resamples<'a, X, Y> {
         Resamples {
             range: Range::new(0, data.0.len()),

--- a/stats/src/float.rs
+++ b/stats/src/float.rs
@@ -1,0 +1,18 @@
+//! Float trait
+
+use num_traits::float;
+use cast::From;
+
+/// This is an extension of `num_traits::float::Float` that adds safe
+/// casting and Sync + Send. Once `num_traits` has these features this
+/// can be removed.
+pub trait Float
+    : float::Float
+    + From<usize, Output=Self>
+    + From<f32, Output=Self>
+    + Sync
+    + Send
+{}
+
+impl Float for f32 {}
+impl Float for f64 {}

--- a/stats/src/lib.rs
+++ b/stats/src/lib.rs
@@ -17,7 +17,7 @@
 #![cfg_attr(clippy, allow(used_underscore_binding))]
 
 extern crate cast;
-extern crate floaty;
+extern crate num_traits;
 extern crate num_cpus;
 extern crate rand;
 extern crate thread_scoped;
@@ -34,17 +34,18 @@ pub mod bivariate;
 pub mod tuple;
 pub mod univariate;
 
+mod float;
+
 use std::mem;
 use std::ops::Deref;
 
-use floaty::Floaty;
-
+use float::Float;
 use univariate::Sample;
 
 /// The bootstrap distribution of some parameter
 pub struct Distribution<A>(Box<[A]>);
 
-impl<A> Distribution<A> where A: Floaty {
+impl<A> Distribution<A> where A: Float {
     /// Computes the confidence interval of the population parameter using percentiles
     ///
     /// # Panics
@@ -106,13 +107,13 @@ pub enum Tails {
 }
 
 fn dot<A>(xs: &[A], ys: &[A]) -> A
-    where A: Floaty
+    where A: Float
 {
     xs.iter().zip(ys).fold(A::cast(0), |acc, (&x, &y)| acc + x * y)
 }
 
 fn sum<A>(xs: &[A]) -> A
-    where A: Floaty
+    where A: Float
 {
     use std::ops::Add;
 

--- a/stats/src/univariate/kde/kernel.rs
+++ b/stats/src/univariate/kde/kernel.rs
@@ -1,17 +1,17 @@
 //! Kernels
 
-use floaty::Floaty;
+use ::float::Float;
 
 /// Kernel function
-pub trait Kernel<A>: Copy + Fn(A) -> A + Sync where A: Floaty {}
+pub trait Kernel<A>: Copy + Fn(A) -> A + Sync where A: Float {}
 
-impl<A, K> Kernel<A> for K where K: Copy + Fn(A) -> A + Sync, A: Floaty {}
+impl<A, K> Kernel<A> for K where K: Copy + Fn(A) -> A + Sync, A: Float {}
 
 /// Gaussian kernel
 #[derive(Clone, Copy)]
 pub struct Gaussian;
 
-impl<A> Fn<(A,)> for Gaussian where A: Floaty {
+impl<A> Fn<(A,)> for Gaussian where A: Float {
     extern "rust-call" fn call(&self, (x,): (A,)) -> A {
         use std::f32::consts::PI;
 
@@ -19,13 +19,13 @@ impl<A> Fn<(A,)> for Gaussian where A: Floaty {
     }
 }
 
-impl<A> FnMut<(A,)> for Gaussian where A: Floaty {
+impl<A> FnMut<(A,)> for Gaussian where A: Float {
     extern "rust-call" fn call_mut(&mut self, args: (A,)) -> A {
         self.call(args)
     }
 }
 
-impl<A> FnOnce<(A,)> for Gaussian where A: Floaty {
+impl<A> FnOnce<(A,)> for Gaussian where A: Float {
     type Output = A;
 
     extern "rust-call" fn call_once(self, args: (A,)) -> A {
@@ -82,4 +82,3 @@ mod test {
     test!(f32);
     test!(f64);
 }
-

--- a/stats/src/univariate/kde/mod.rs
+++ b/stats/src/univariate/kde/mod.rs
@@ -4,7 +4,7 @@ pub mod kernel;
 
 use std::ptr;
 
-use floaty::Floaty;
+use ::float::Float;
 use num_cpus;
 use thread_scoped as thread;
 
@@ -13,13 +13,13 @@ use univariate::Sample;
 use self::kernel::Kernel;
 
 /// Univariate kernel density estimator
-pub struct Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
+pub struct Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     bandwidth: A,
     kernel: K,
     sample: &'a Sample<A>,
 }
 
-impl<'a, A, K> Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
+impl<'a, A, K> Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     /// Creates a new kernel density estimator from the `sample`, using a kernel `k` and estimating
     /// the bandwidth using the method `bw`
     pub fn new(sample: &'a Sample<A>, k: K, bw: Bandwidth<A>) -> Kde<'a, A, K> {
@@ -70,7 +70,7 @@ impl<'a, A, K> Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     }
 }
 
-impl<'a, A, K> Fn<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
+impl<'a, A, K> Fn<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     /// Estimates the probability density of `x`
     extern "rust-call" fn call(&self, (x,): (A,)) -> A {
         let _0 = A::cast(0);
@@ -84,13 +84,13 @@ impl<'a, A, K> Fn<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
     }
 }
 
-impl<'a, A, K> FnMut<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
+impl<'a, A, K> FnMut<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     extern "rust-call" fn call_mut(&mut self, args: (A,)) -> A {
         self.call(args)
     }
 }
 
-impl<'a, A, K> FnOnce<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A> {
+impl<'a, A, K> FnOnce<(A,)> for Kde<'a, A, K> where A: 'a + Float, K: Kernel<A> {
     type Output = A;
 
     extern "rust-call" fn call_once(self, args: (A,)) -> A {
@@ -99,14 +99,14 @@ impl<'a, A, K> FnOnce<(A,)> for Kde<'a, A, K> where A: 'a + Floaty, K: Kernel<A>
 }
 
 /// Method to estimate the bandwidth
-pub enum Bandwidth<A> where A: Floaty {
+pub enum Bandwidth<A> where A: Float {
     /// Use this value as the bandwidth
     Manual(A),
     /// Use Silverman's rule of thumb to estimate the bandwidth from the sample
     Silverman,
 }
 
-impl<A> Bandwidth<A> where A: Floaty {
+impl<A> Bandwidth<A> where A: Float {
     fn estimate(self, sample: &Sample<A>) -> A {
         match self {
             Bandwidth::Silverman => {

--- a/stats/src/univariate/mixed.rs
+++ b/stats/src/univariate/mixed.rs
@@ -3,7 +3,7 @@
 use std::ptr::Unique;
 use std::{cmp, mem};
 
-use floaty::Floaty;
+use ::float::Float;
 use num_cpus;
 use thread_scoped as thread;
 
@@ -18,7 +18,7 @@ pub fn bootstrap<A, T, S>(
     nresamples: usize,
     statistic: S,
 ) -> T::Distributions where
-    A: Floaty,
+    A: Float,
     S: Fn(&Sample<A>, &Sample<A>) -> T + Sync,
     T: Tuple,
     T::Distributions: Send,

--- a/stats/src/univariate/mod.rs
+++ b/stats/src/univariate/mod.rs
@@ -9,7 +9,7 @@ pub mod kde;
 pub mod mixed;
 pub mod outliers;
 
-use floaty::Floaty;
+use ::float::Float;
 
 use tuple::{Tuple, TupledDistributions};
 
@@ -30,8 +30,8 @@ pub fn bootstrap<A, B, T, S>(
     nresamples: usize,
     statistic: S,
 ) -> T::Distributions where
-    A: Floaty,
-    B: Floaty,
+    A: Float,
+    B: Float,
     S: Fn(&Sample<A>, &Sample<B>) -> T,
     S: Sync,
     T: Tuple,

--- a/stats/src/univariate/outliers/tukey.rs
+++ b/stats/src/univariate/outliers/tukey.rs
@@ -42,7 +42,7 @@ use std::ops::{Deref, Index};
 use std::slice;
 
 use cast;
-use floaty::Floaty;
+use ::float::Float;
 
 use univariate::Sample;
 
@@ -57,12 +57,12 @@ use self::Label::*;
 /// `IndexGet` trait lands in stdlib, the indexing operation will return a `(data_point, label)`
 /// pair.
 #[derive(Clone, Copy)]
-pub struct LabeledSample<'a, A> where A: 'a + Floaty {
+pub struct LabeledSample<'a, A> where A: 'a + Float {
     fences: (A, A, A, A),
     sample: &'a Sample<A>,
 }
 
-impl<'a, A> LabeledSample<'a, A> where A: Floaty {
+impl<'a, A> LabeledSample<'a, A> where A: Float {
     /// Returns the number of data points per label
     ///
     /// - Time: `O(length)`
@@ -107,7 +107,7 @@ impl<'a, A> LabeledSample<'a, A> where A: Floaty {
     }
 }
 
-impl<'a, A> Deref for LabeledSample<'a, A> where A: Floaty {
+impl<'a, A> Deref for LabeledSample<'a, A> where A: Float {
     type Target = Sample<A>;
 
     fn deref(&self) -> &Sample<A> {
@@ -116,7 +116,7 @@ impl<'a, A> Deref for LabeledSample<'a, A> where A: Floaty {
 }
 
 // FIXME Use the `IndexGet` trait
-impl<'a, A> Index<usize> for LabeledSample<'a, A> where A: Floaty {
+impl<'a, A> Index<usize> for LabeledSample<'a, A> where A: Float {
     type Output = Label;
 
     #[cfg_attr(clippy, allow(similar_names))]
@@ -144,7 +144,7 @@ impl<'a, A> Index<usize> for LabeledSample<'a, A> where A: Floaty {
     }
 }
 
-impl<'a, 'b, A> IntoIterator for &'b LabeledSample<'a, A> where A: Floaty {
+impl<'a, 'b, A> IntoIterator for &'b LabeledSample<'a, A> where A: Float {
     type Item = (A, Label);
     type IntoIter = Iter<'a, A>;
 
@@ -154,12 +154,12 @@ impl<'a, 'b, A> IntoIterator for &'b LabeledSample<'a, A> where A: Floaty {
 }
 
 /// Iterator over the labeled data
-pub struct Iter<'a, A> where A: 'a + Floaty {
+pub struct Iter<'a, A> where A: 'a + Float {
     fences: (A, A, A, A),
     iter: slice::Iter<'a, A>,
 }
 
-impl<'a, A> Iterator for Iter<'a, A> where A: Floaty {
+impl<'a, A> Iterator for Iter<'a, A> where A: Float {
     type Item = (A, Label);
 
     #[cfg_attr(clippy, allow(similar_names))]
@@ -248,7 +248,7 @@ impl Label {
 ///
 /// - Time: `O(N log N) where N = length`
 pub fn classify<A>(sample: &Sample<A>) -> LabeledSample<A> where
-    A: Floaty,
+    A: Float,
     usize: cast::From<A, Output=Result<usize, cast::Error>>,
 {
     let (q1, _, q3) = sample.percentiles().quartiles();

--- a/stats/src/univariate/percentiles.rs
+++ b/stats/src/univariate/percentiles.rs
@@ -1,11 +1,11 @@
 use cast::{self, usize};
-use floaty::Floaty;
+use ::float::Float;
 
 /// A "view" into the percentiles of a sample
-pub struct Percentiles<A>(Box<[A]>) where A: Floaty;
+pub struct Percentiles<A>(Box<[A]>) where A: Float;
 
 // TODO(rust-lang/rfcs#735) move this `impl` into a private percentiles module
-impl<A> Percentiles<A> where A: Floaty, usize: cast::From<A, Output=Result<usize, cast::Error>> {
+impl<A> Percentiles<A> where A: Float, usize: cast::From<A, Output=Result<usize, cast::Error>> {
     /// Returns the percentile at `p`%
     ///
     /// Safety:
@@ -73,4 +73,3 @@ impl<A> Percentiles<A> where A: Floaty, usize: cast::From<A, Output=Result<usize
         }
     }
 }
-

--- a/stats/src/univariate/resamples.rs
+++ b/stats/src/univariate/resamples.rs
@@ -1,12 +1,12 @@
 use std::mem;
 
-use floaty::Floaty;
+use ::float::Float;
 use rand::distributions::{IndependentSample, Range};
 use rand::{Rng, XorShiftRng};
 
 use univariate::Sample;
 
-pub struct Resamples<'a, A> where A: 'a + Floaty {
+pub struct Resamples<'a, A> where A: 'a + Float {
     range: Range<usize>,
     rng: XorShiftRng,
     sample: &'a [A],
@@ -14,7 +14,7 @@ pub struct Resamples<'a, A> where A: 'a + Floaty {
 }
 
 #[cfg_attr(clippy, allow(should_implement_trait))]
-impl <'a, A> Resamples<'a, A> where A: 'a + Floaty {
+impl <'a, A> Resamples<'a, A> where A: 'a + Float {
     pub fn new(sample: &'a Sample<A>) -> Resamples<'a, A> {
         let slice = sample.as_slice();
 

--- a/stats/src/univariate/sample.rs
+++ b/stats/src/univariate/sample.rs
@@ -2,7 +2,7 @@ use std::ptr::Unique;
 use std::{cmp, mem};
 
 use cast;
-use floaty::Floaty;
+use ::float::Float;
 use num_cpus;
 use thread_scoped as thread;
 
@@ -34,7 +34,7 @@ impl<A> Sample<A> {
 }
 
 // TODO(rust-lang/rfcs#735) move this `impl` into a private percentiles module
-impl<A> Sample<A> where A: Floaty {
+impl<A> Sample<A> where A: Float {
     /// Creates a new sample from an existing slice
     ///
     /// # Panics


### PR DESCRIPTION
At the moment num_traits::float::Float doesn't have Sync or Send, and conversion from a primitive always returns an Option. Add a small Float trait that adds more convenient safe casting and can be used with threads.

Also fixes some small clippy warnings.

Fixes #95.