### PR TITLE
Minor book additions for migration from libtest

### DIFF
--- a/book/src/user_guide/migrating_from_libtest.md
+++ b/book/src/user_guide/migrating_from_libtest.md
@@ -37,6 +37,13 @@ name = "example"
 harness = false
 ```
 
+We also need to add Criterion.rs to the `dev-dependencies` section of `Cargo.toml`:
+
+```toml
+[dev-dependencies]
+criterion = "0.1.2"
+```
+
 The next step is to update the imports:
 
 ```rust
@@ -59,8 +66,8 @@ Finally, we need to invoke some macros to generate a main function, since we
 no longer have libtest to provide one:
 
 ```rust
-criterion_group(benches, bench_fib);
-criterion_main(benches);
+criterion_group!(benches, bench_fib);
+criterion_main!(benches);
 ```
 
 And that's it! The complete migrated benchmark code is below:


### PR DESCRIPTION
Added step for adding `dev-dependencies` and also appended missing `!` for macro invocations.

On a side note, I see that the line endings may have been changed as a result. I'm happy to change these to whatever is preferred however may I suggest also adding an [`.editorconfig`](http://editorconfig.org/)? This will help maintain consistency going forward.