### PR TITLE
deps: Update handlebars.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 atty = "0.2"
 clap = "2.29"
-handlebars = { version = "0.31", optional = true }
+handlebars = { version = "0.32", optional = true }
 
 [dev-dependencies]
 walkdir = "2.1"


### PR DESCRIPTION
Moving to handlebars 0.32.1 brings an update to the regex dependency
to 1.0.