### PR TITLE
Add csv report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 atty = "0.2"
 clap = "2.29"
+csv = { version = "1", optional = true }
 handlebars = { version = "0.32", optional = true }
 
 [dev-dependencies]
@@ -40,7 +41,8 @@ maintenance = { status = "passively-maintained" }
 [features]
 real_blackbox = []
 html_reports = ["handlebars", "criterion-plot"]
-default = ["html_reports"]
+csv_reports = ["csv"]
+default = ["html_reports", "csv_reports"]
 
 [workspace]
 

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -597,6 +597,7 @@ where
 
         let mut any_matched = false;
 
+        c.report.report_init(&report_context);
         for routine in self.routines {
             for value in &self.values {
                 let function_id = if num_routines == 1 && group_id == routine.id {

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -358,6 +358,7 @@ impl BenchmarkDefinition for Benchmark {
             output_directory: c.output_directory.clone(),
             plotting: c.plotting,
             plot_config: self.config.plot_config.clone(),
+            module: c.module.clone(),
         };
 
         let config = self.config.to_complete(&c.config);
@@ -585,6 +586,7 @@ where
             output_directory: c.output_directory.clone(),
             plotting: c.plotting,
             plot_config: self.config.plot_config.clone(),
+            module: c.module.clone(),
         };
 
         let config = self.config.to_complete(&c.config);

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -366,6 +366,7 @@ impl BenchmarkDefinition for Benchmark {
         let mut all_ids = vec![];
         let mut any_matched = false;
 
+        c.report.report_init(&report_context);
         for routine in self.routines {
             let function_id = if num_routines == 1 && group_id == routine.id {
                 None

--- a/src/csv_reports.rs
+++ b/src/csv_reports.rs
@@ -1,0 +1,51 @@
+use csv::Writer;
+use failure;
+use fs;
+use report::{BenchmarkId, MeasurementData, Report, ReportContext};
+use std::path::Path;
+
+pub struct CsvReport {}
+
+impl CsvReport {
+    pub fn new() -> CsvReport {
+        CsvReport {}
+    }
+}
+
+impl Report for CsvReport {
+    fn report_init(&self, report_context: &ReportContext) {
+        let path = Path::new(&report_context.output_directory).join("benchmark-raw.csv");
+        try_else_return!(fs::save_string("group,function,parameter,elapsed\n", &path));
+    }
+
+    fn benchmark_start(&self, _: &BenchmarkId, _: &ReportContext) {}
+    fn warmup(&self, _: &BenchmarkId, _: &ReportContext, _: f64) {}
+    fn terminated(&self, _: &BenchmarkId, _: &ReportContext) {}
+    fn analysis(&self, _: &BenchmarkId, _: &ReportContext) {}
+    fn measurement_start(&self, _: &BenchmarkId, _: &ReportContext, _: u64, _: f64, _: u64) {}
+    fn final_summary(&self, _: &ReportContext) {}
+    fn summarize(&self, _: &ReportContext, _: &[BenchmarkId]) {}
+    fn measurement_complete(
+        &self,
+        id: &BenchmarkId,
+        report_context: &ReportContext,
+        measurements: &MeasurementData,
+    ) {
+        let path = Path::new(&report_context.output_directory).join("benchmark-raw.csv");
+        let output = try_else_return!(fs::append(path));
+        let mut wtr = Writer::from_writer(output);
+
+        for avg_time in measurements.avg_times.as_slice() {
+            let write_res = wtr.write_record(&[
+                id.group_id.as_str(),
+                &id.function_id.as_ref().map_or("", String::as_str),
+                &id.value_str.as_ref().map_or("", String::as_str),
+                &avg_time.to_string(),
+            ]);
+
+            try_else_return!(write_res.map_err(failure::Error::from));
+        }
+
+        try_else_return!(wtr.flush().map_err(failure::Error::from));
+    }
+}

--- a/src/csv_reports.rs
+++ b/src/csv_reports.rs
@@ -14,7 +14,16 @@ impl CsvReport {
 
 impl Report for CsvReport {
     fn report_init(&self, report_context: &ReportContext) {
-        let path = Path::new(&report_context.output_directory).join("benchmark-raw.csv");
+        let parent = Path::new(&report_context.output_directory);
+        try_else_return!(fs::mkdirp(&parent));
+
+        let path = parent.join(&format!(
+            "{}-raw.csv",
+            report_context
+                .module
+                .as_ref()
+                .map_or("benchmark", String::as_str)
+        ));
         try_else_return!(fs::save_string("group,function,parameter,elapsed\n", &path));
     }
 
@@ -31,7 +40,13 @@ impl Report for CsvReport {
         report_context: &ReportContext,
         measurements: &MeasurementData,
     ) {
-        let path = Path::new(&report_context.output_directory).join("benchmark-raw.csv");
+        let path = Path::new(&report_context.output_directory).join(&format!(
+            "{}-raw.csv",
+            report_context
+                .module
+                .as_ref()
+                .map_or("benchmark", String::as_str)
+        ));
         let output = try_else_return!(fs::append(path));
         let mut wtr = Writer::from_writer(output);
 

--- a/src/csv_reports.rs
+++ b/src/csv_reports.rs
@@ -38,8 +38,8 @@ impl Report for CsvReport {
         for avg_time in measurements.avg_times.as_slice() {
             let write_res = wtr.write_record(&[
                 id.group_id.as_str(),
-                &id.function_id.as_ref().map_or("", String::as_str),
-                &id.value_str.as_ref().map_or("", String::as_str),
+                id.function_id.as_ref().map_or("", String::as_str),
+                id.value_str.as_ref().map_or("", String::as_str),
                 &avg_time.to_string(),
             ]);
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json;
-use std::fs::{self, File};
+use std::fs::{self, File, OpenOptions};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -21,6 +21,10 @@ where
     let result: A = serde_json::from_str(string.as_str())?;
 
     Ok(result)
+}
+
+pub fn append<P: AsRef<Path>>(path: P) -> Result<File> {
+    Ok(OpenOptions::new().append(true).open(path)?)
 }
 
 pub fn mkdirp<P>(path: &P) -> Result<()>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,6 +426,7 @@ pub struct Criterion {
     config: BenchmarkConfig,
     plotting: Plotting,
     filter: Option<String>,
+    module: Option<String>,
     report: Box<Report>,
     output_directory: String,
     measure_only: bool,
@@ -479,6 +480,7 @@ impl Default for Criterion {
             },
             plotting,
             filter: None,
+            module: None,
             report: Box::new(Reports::new(reports)),
             output_directory: "target/criterion".to_owned(),
             measure_only: false,
@@ -626,6 +628,13 @@ impl Criterion {
         }
     }
 
+    /// Sets the name of the module being benchmarked
+    pub fn with_module<S: Into<String>>(mut self, module: S) -> Criterion {
+        self.module = Some(module.into());
+
+        self
+    }
+
     /// Filters the benchmarks. Only benchmarks with names that contain the
     /// given string will be executed.
     pub fn with_filter<S: Into<String>>(mut self, filter: S) -> Criterion {
@@ -649,6 +658,7 @@ impl Criterion {
             output_directory: self.output_directory.clone(),
             plotting: self.plotting,
             plot_config: PlotConfiguration::default(),
+            module: self.module.clone(),
         };
         self.report.final_summary(&report_context);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ extern crate serde;
 extern crate serde_json;
 extern crate simplelog;
 
+#[cfg(feature = "csv_reports")]
+extern crate csv;
+
 #[cfg(feature = "html_reports")]
 extern crate criterion_plot;
 
@@ -73,6 +76,9 @@ mod plot;
 #[cfg(feature = "html_reports")]
 mod html;
 
+#[cfg(feature = "csv_reports")]
+mod csv_reports;
+
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::default::Default;
@@ -90,6 +96,9 @@ use routine::Function;
 
 #[cfg(feature = "html_reports")]
 use html::Html;
+
+#[cfg(feature = "csv_reports")]
+use csv_reports::CsvReport;
 
 pub use benchmark::{Benchmark, BenchmarkDefinition, ParameterizedBenchmark};
 
@@ -453,6 +462,11 @@ impl Default for Criterion {
             reports.push(Box::new(Html::new()));
         }
 
+        #[cfg(feature = "csv_reports")]
+        {
+            reports.push(Box::new(CsvReport::new()));
+        }
+
         Criterion {
             config: BenchmarkConfig {
                 confidence_level: 0.95,
@@ -722,6 +736,13 @@ scripts alongside the generated plots.
         {
             if !self.measure_only {
                 reports.push(Box::new(Html::new()));
+            }
+        }
+
+        #[cfg(feature = "csv_reports")]
+        {
+            if !self.measure_only {
+                reports.push(Box::new(CsvReport::new()));
             }
         }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,7 +72,7 @@ macro_rules! criterion_group {
     ($name:ident, $( $target:path ),+ $(,)*) => {
         criterion_group!{
             name = $name;
-            config = Criterion::default();
+            config = Criterion::default().with_module(module_path!());
             targets = $( $target ),+
         }
     }
@@ -123,6 +123,7 @@ macro_rules! criterion_main {
             )+
 
             criterion::Criterion::default()
+                .with_module(module_path!())
                 .configure_from_args()
                 .final_summary();
         }

--- a/src/report.rs
+++ b/src/report.rs
@@ -128,6 +128,7 @@ pub struct ReportContext {
     pub output_directory: String,
     pub plotting: Plotting,
     pub plot_config: PlotConfiguration,
+    pub module: Option<String>,
 }
 
 pub(crate) trait Report {

--- a/src/report.rs
+++ b/src/report.rs
@@ -131,6 +131,7 @@ pub struct ReportContext {
 }
 
 pub(crate) trait Report {
+    fn report_init(&self, _context: &ReportContext) {}
     fn benchmark_start(&self, id: &BenchmarkId, context: &ReportContext);
     fn warmup(&self, id: &BenchmarkId, context: &ReportContext, warmup_ns: f64);
     fn terminated(&self, id: &BenchmarkId, context: &ReportContext);
@@ -162,6 +163,12 @@ impl Reports {
     }
 }
 impl Report for Reports {
+    fn report_init(&self, context: &ReportContext) {
+        for report in &self.reports {
+            report.report_init(context);
+        }
+    }
+
     fn benchmark_start(&self, id: &BenchmarkId, context: &ReportContext) {
         for report in &self.reports {
             report.benchmark_start(id, context);

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -28,6 +28,7 @@ fn temp_dir() -> TempDir {
 fn short_benchmark(dir: &TempDir) -> Criterion {
     Criterion::default()
         .output_directory(dir.path())
+        .with_module("test-criterion")
         .warm_up_time(Duration::from_millis(250))
         .measurement_time(Duration::from_millis(500))
         .nresamples(1000)
@@ -341,7 +342,7 @@ fn test_output_files() {
     }
 
     #[cfg(feature = "csv_reports")]
-    verify_file(&tempdir.path().to_path_buf(), "benchmark-raw.csv");
+    verify_file(&tempdir.path().to_path_buf(), "test-criterion-raw.csv");
 
     for x in 0..2 {
         let dir = tempdir.path().join(format!("test_output/output_{}", x + 1));

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -340,6 +340,8 @@ fn test_output_files() {
         verify_file(dir, path);
     }
 
+    verify_file(&tempdir.path().to_path_buf(), "benchmark-raw.csv");
+
     for x in 0..2 {
         let dir = tempdir.path().join(format!("test_output/output_{}", x + 1));
 

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -340,6 +340,7 @@ fn test_output_files() {
         verify_file(dir, path);
     }
 
+    #[cfg(feature = "csv_reports")]
     verify_file(&tempdir.path().to_path_buf(), "benchmark-raw.csv");
 
     for x in 0..2 {


### PR DESCRIPTION
This PR adds a CSV report that contains all the sampling data across all benchmarks in a `benchmark-raw.csv`. It appears like the following:

| group | function | parameter | elapsed |
| -------- | -- | --------- | ------------ |
| a           | b  |                | 100             |
| a           | b  |                | 150             |

Like `html_reports`, `csv_reports` is feature that is enabled by default.

Some thoughts:

- Assuming that adding `Report::report_init` is necessary (to clear out file and add csv header) -- what is your name preference? `report_start` is another possibility ... or some other name
- I created a default implementation for `report_init` for all reports. I noticed that this goes against the current style, but I couldn't think of why all the `Report` impls need to define all the functions (instead of relying on the default empty function).
- Ideally if I'm running `bencha.rs` then the csv would be `bencha-raw.csv`, but I didn't see that info available (I could be missing something). This may not be a big issue as I only tend to see projects use only a single file for benchmarks.

I've tested this on some of my crates and things looks great

EDIT: related #147