### PR TITLE
Add --no-overwrite option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added a `--no-overwrite` argument which causes the benchmark executable to run
+  the  warmup, measurement, and analysis then move on to the next benchmark without
+  saving data. This is useful when iterating against a baseline
+  (eg. comparing a feature branch to the commit it branches off master)
 
 ## [0.2.3]
 ### Fixed

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -358,6 +358,7 @@ impl BenchmarkDefinition for Benchmark {
             output_directory: c.output_directory.clone(),
             plotting: c.plotting,
             plot_config: self.config.plot_config.clone(),
+            no_overwrite: c.no_overwrite,
         };
 
         let config = self.config.to_complete(&c.config);
@@ -584,6 +585,7 @@ where
             output_directory: c.output_directory.clone(),
             plotting: c.plotting,
             plot_config: self.config.plot_config.clone(),
+            no_overwrite: c.no_overwrite,
         };
 
         let config = self.config.to_complete(&c.config);

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -159,7 +159,7 @@ impl Report for Html {
         report_context: &ReportContext,
         measurements: &MeasurementData,
     ) {
-        if !report_context.plotting.is_enabled() {
+        if !report_context.plotting.is_enabled() || report_context.no_overwrite {
             return;
         }
 
@@ -250,7 +250,7 @@ impl Report for Html {
     }
 
     fn summarize(&self, context: &ReportContext, all_ids: &[BenchmarkId]) {
-        if !context.plotting.is_enabled() {
+        if !context.plotting.is_enabled() || context.no_overwrite {
             return;
         }
 
@@ -293,7 +293,7 @@ impl Report for Html {
     }
 
     fn final_summary(&self, report_context: &ReportContext) {
-        if !report_context.plotting.is_enabled() {
+        if !report_context.plotting.is_enabled() || report_context.no_overwrite {
             return;
         }
         //TODO: Once criterion.rs moves to a proc-macro test harness, we should ensure that we have

--- a/src/report.rs
+++ b/src/report.rs
@@ -128,6 +128,7 @@ pub struct ReportContext {
     pub output_directory: String,
     pub plotting: Plotting,
     pub plot_config: PlotConfiguration,
+    pub no_overwrite: bool,
 }
 
 pub(crate) trait Report {


### PR DESCRIPTION
This disables saving results to disk post-analysis.

This is useful when iterating against a baseline(eg. comparing a feature branch to the commit it branches off master)

Typical use is an initial `cargo bench` to build a baseline then every future bench using `--no-overwrite`.

Specifically, this introduces two new attributes on Criterion and ReportContext, `no_overwrite`. Whenever Criterion is associated with a ReportContext, `no_overwrite` is copied over. This flag indicates to all reports that they should never modify the filesystem.

An associated test, `test_without_overwrite`, has been added. This ensures that the previous results are neither mutated nor removed.

Closes #150