### PR TITLE
Add --save-baseline and --baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a pair of flags, `--save-baseline` and `--baseline`, which change
+  how benchmark results are stored and compared. This is useful for
+  working against a fixed baseline(eg. comparing progress on an
+  optimization feature branch to the commit it forked from).
+  Default behavior of Criterion.rs is now `--save-baseline base`
+  which emulates the previous, user facing behavior.
+  - `--save-baseline` saves the benchmark results under the provided name.
+  - `--baseline` compares the results to a saved baseline.
+    If the baseline does not exist for a benchmark, an error is given.
 
 ## [0.2.3]
 ### Fixed

--- a/src/analysis/compare.rs
+++ b/src/analysis/compare.rs
@@ -28,12 +28,15 @@ pub(crate) fn common(
     Vec<f64>,
     Estimates,
 )> {
-    let sample_dir = format!("{}/{}/base/sample.json", criterion.output_directory, id);
+    let sample_dir = format!(
+        "{}/{}/{}/sample.json",
+        criterion.output_directory, id, criterion.baseline_directory
+    );
     let (iters, times): (Vec<f64>, Vec<f64>) = fs::load(&sample_dir)?;
 
     let base_estimates: Estimates = fs::load(&format!(
-        "{}/{}/base/estimates.json",
-        criterion.output_directory, id
+        "{}/{}/{}/estimates.json",
+        criterion.output_directory, id, criterion.baseline_directory
     ))?;
 
     let base_avg_times: Vec<f64> = iters

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -31,14 +31,8 @@ where
     Ok(())
 }
 
-pub fn mv(from: &Path, to: &Path) -> Result<()> {
-    fs::rename(from, to)?;
-    Ok(())
-}
-
-pub fn rmrf(path: &Path) -> Result<()> {
-    fs::remove_dir_all(path)?;
-
+pub fn cp(from: &Path, to: &Path) -> Result<()> {
+    fs::copy(from, to)?;
     Ok(())
 }
 


### PR DESCRIPTION
Previously, Criterion.rs would store previous results in a single
directory, `.../base`. On every benchmark run, the `base`
directory would be overwritten. This behavior prevented comparison
to a known point while iterating on optimizations.

This change introduces the idea of baselines; a named directory
for results generated at some point in the past.  The default
behavior of using and overwriting the `base` directory is still
the same as before. However, these two new options allow the
user to explicitly name and compare to baselines.

`--save-baseline` creates and stores the results for that
benchmark run under a directory with the same name as that
baseline.

`--baseline` compares the results for the current run against
the baseline results. It loudly fails if the baseline is not
present for a specific benchmark.

Previous behavior is emulated using `--save-baseline base` when
no explicit baseline is named.

As discussed on #153
Closes #150 as a more flexible solution.

---

This does differ from what we discussed in that reports still live in the `report` directory rather than be namespaced under the baseline. Storing only the benchmark stats under the baseline simplifies the process of saving it. I can move the reports in a followup PR as this one is already rather heavy.

The verify methods in the tests have been factored out of `test_output_files` to make them available to the baseline tests.