### PR TITLE
Improve error message when loading estimates file

### DIFF
--- a/src/analysis/compare.rs
+++ b/src/analysis/compare.rs
@@ -33,11 +33,12 @@ pub(crate) fn common(
         criterion.output_directory, id, criterion.baseline_directory
     );
     let (iters, times): (Vec<f64>, Vec<f64>) = fs::load(&sample_dir)?;
-
-    let base_estimates: Estimates = fs::load(&format!(
-        "{}/{}/{}/estimates.json",
-        criterion.output_directory, id, criterion.baseline_directory
-    ))?;
+    
+    let estimates_file =
+        &format!("{}/{}/base/estimates.json", criterion.output_directory, id);
+    let base_estimates: Estimates = fs::load(&estimates_file).map_err(|e| {
+        e.context(format!("Failed to load {}!", &estimates_file))
+    })?;
 
     let base_avg_times: Vec<f64> = iters
         .iter()


### PR DESCRIPTION
Closes https://github.com/japaric/criterion.rs/issues/164.

I went for the least intrusive approach, since I don't know the codebase very well. Since you're using failure, it was very easy to add a bit of context here.

I know `context` with `format` has a bit of a performance penalty, but for `with_context` one needs a `Fail` rather than a `failure::Error`, and I'm not sure how to arrange that or if that's even what one wants. Otoh, when loading a file, an additional `format` is probably dwarfed by everything else...