### PR TITLE
sort sub-benchmarks by name (fixes #179)

### DIFF
--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -308,10 +308,11 @@ impl Report for Html {
                 .file_name()
                 .map(|name| name.to_string_lossy())
                 .unwrap();
-            let sub_benchmarks = fs::list_existing_reports(&base_dir)?
+            let mut sub_benchmarks = fs::list_existing_reports(&base_dir)?
                 .into_iter()
                 .map(|sub_path| path_to_individual_benchmark(&sub_path, output_directory))
                 .collect::<Result<Vec<_>>>()?;
+            sub_benchmarks.sort_unstable_by_key(|k| k.name.clone());
             Ok(IndexBenchmark {
                 name: name.to_string(),
                 path: path.join("index.html")


### PR DESCRIPTION
This sorts the sub-benchmarks by name when generating an HTML report, resolving #179 (assuming you agree that we should fix that! I know that this PR is putting the cart before the horse, as we haven't had any discussion in that issue yet, but I figured it would be a small change, and I wanted to familiarize myself with the codebase).

Note that [CONTRIBUTING](https://github.com/japaric/criterion.rs/blob/master/CONTRIBUTING.md) suggests to run `cargo +nightly fmt`, but that currently fails for me with:

```
thread 'main' panicked at 'not yet implemented', tools/rustfmt/src/expr.rs:346:47
```

Which is https://github.com/rust-lang-nursery/rustfmt/issues/2743. However, I don't foresee any formatting issues with this small (two-line) change. And in any case rustfmt makes a bunch of other changes to the code before panicking, so it looks like the codebase hasn't been getting formatted lately (or at least not with recent versions of rustfmt!).
