### PR TITLE
Unindent `Cargo.toml` additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ In order to generate plots, you must have [gnuplot](http://www.gnuplot.info/) in
 To start with Criterion.<span></span>rs, add the following to your `Cargo.toml` file:
 
 ```toml
-    [dev-dependencies]
-    criterion = "0.2"
+[dev-dependencies]
+criterion = "0.2"
 
-    [[bench]]
-    name = "my_benchmark"
-    harness = false
+[[bench]]
+name = "my_benchmark"
+harness = false
 ```
 
 Next, define a benchmark by creating a file at `$PROJECT/benches/my_benchmark.rs` with the following contents.


### PR DESCRIPTION
Typically sections in Cargo.toml do not start out indented. By using both code block syntax and indenting 4 spaces, you have inadvertently made it so that people copying and pasting those lines end up with something indented that shouldn't be indented.

This change fixes that.