### PR TITLE
Support custom test frameworks behind ctf feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ backtrace = "0.3.5" # required only for minimal-versions. brought in by failure.
 chrono = "0.4.6" # required only for minimal-versions. brought in by simplelog.
 criterion-plot = { path="plot", version="0.2.5", optional = true }
 criterion-stats = { path="stats", version="0.2.5" }
+criterion-macro = { path="macro", version="0.2.5", optional = true }
 failure = "0.1.2"
 failure_derive = "0.1.1"
 itertools = "0.7"
@@ -44,6 +45,7 @@ maintenance = { status = "passively-maintained" }
 real_blackbox = []
 html_reports = ["handlebars", "criterion-plot"]
 default = ["html_reports"]
+ctf = [ "criterion-macro" ]
 
 [workspace]
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "criterion-macro"
+version = "0.2.5"
+authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+path = "lib.rs"
+
+[dependencies]
+proc-macro2 = { version = "0.4", features = ["nightly"] }
+quote = "0.6"

--- a/macro/lib.rs
+++ b/macro/lib.rs
@@ -1,0 +1,60 @@
+//! `#[criterion]` macro
+
+extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+
+use proc_macro2::{Ident, TokenStream, TokenTree};
+
+#[proc_macro_attribute]
+pub fn criterion(
+    attr: proc_macro::TokenStream, item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let tokens = TokenStream::from(attr).into_iter().collect::<Vec<_>>();
+
+    if tokens.len() != 0 {
+        panic!("expected #[criterion]");
+    }
+
+    let item = TokenStream::from(item);
+    let name = find_fn_name(item.clone());
+
+    let name: TokenStream = name
+        .to_string()
+        .parse()
+        .expect(&format!("failed to parse name: {}", name.to_string()));
+
+    let mut bench_const: String = name.to_string();
+    bench_const += "_const";
+    let bench_const: TokenStream = bench_const.parse().expect(&format!("failed to
+    parse name: {}", bench_const.to_string()));
+
+    let ret: TokenStream = quote_spanned! {
+        proc_macro2::Span::call_site() =>
+            #item
+            #[test_case]
+            const #bench_const: ::criterion::CtfBenchmark = ::criterion::CtfBenchmark {
+                name: stringify!(#name),
+                fun: #name,
+            };
+    }.into();
+    ret.into()
+}
+
+/// Find function name
+fn find_fn_name(item: TokenStream) -> Ident {
+    let mut tokens = item.into_iter();
+    while let Some(tok) = tokens.next() {
+        if let TokenTree::Ident(word) = tok {
+            if word == "fn" {
+                break;
+            }
+        }
+    }
+
+    match tokens.next() {
+        Some(TokenTree::Ident(word)) => word,
+        _ => panic!("failed to find function name"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@ extern crate handlebars;
 #[cfg(feature = "real_blackbox")]
 extern crate test;
 
+#[cfg(feature = "ctf")]
+extern crate criterion_macro;
+
 #[macro_use]
 extern crate log;
 
@@ -76,6 +79,9 @@ mod plot;
 #[cfg(feature = "html_reports")]
 mod html;
 
+#[cfg(feature = "ctf")]
+mod runner;
+
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::default::Default;
@@ -94,6 +100,12 @@ use routine::Function;
 
 #[cfg(feature = "html_reports")]
 use html::Html;
+
+#[cfg(feature = "ctf")]
+pub use runner::{CtfBenchmark, runner};
+
+#[cfg(feature = "ctf")]
+pub use criterion_macro::criterion;
 
 pub use benchmark::{Benchmark, BenchmarkDefinition, ParameterizedBenchmark};
 
@@ -943,7 +955,7 @@ scripts alongside the generated plots.
     ///     let sequential_fib = Fun::new("Sequential", bench_seq_fib);
     ///     let parallel_fib = Fun::new("Parallel", bench_par_fib);
     ///     let funs = vec![sequential_fib, parallel_fib];
-    ///   
+    ///
     ///     c.bench_functions("Fibonacci", funs, 14);
     /// }
     ///

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,0 +1,31 @@
+//! custom test-framework runner
+pub use criterion_macro::*;
+use ::*;
+
+/// Benchmark definition for the custom benchmark runner
+#[doc(hidden)]
+pub struct CtfBenchmark {
+    /// Benchmark name
+    pub name: &'static str,
+    /// Benchmark function
+    pub fun: fn(&mut Criterion) ->(),
+}
+
+impl CtfBenchmark {
+    fn run(&self) {
+        let mut criterion: Criterion = Criterion::default();
+        (self.fun)(&mut criterion);
+    }
+}
+
+/// Custom benchmark runner
+#[doc(hidden)]
+pub fn runner(benchmark_groups: &[&CtfBenchmark]) {
+    init_logging();
+    for g in benchmark_groups {
+        g.run();
+    }
+    Criterion::default()
+        .configure_from_args()
+        .final_summary();
+}

--- a/tests/ctf.rs
+++ b/tests/ctf.rs
@@ -1,0 +1,45 @@
+//! Custom test framework support
+#![cfg_attr(feature = "ctf", feature(custom_test_frameworks, proc_macro_gen))]
+#![cfg_attr(feature = "ctf", test_runner(criterion::runner))]
+
+#[cfg(feature = "ctf")]
+extern crate criterion;
+#[cfg(feature = "ctf")]
+use criterion::*;
+
+#[cfg(feature = "ctf")]
+fn fibonacci_slow(n: u64) -> u64 {
+    match n {
+        0 | 1 => 1,
+        n => fibonacci_slow(n - 1) + fibonacci_slow(n - 2),
+    }
+}
+
+#[cfg(feature = "ctf")]
+fn fibonacci_fast(n: u64) -> u64 {
+    let mut a = 0u64;
+    let mut b = 1u64;
+    let mut c: u64;
+
+    if n == 0 {
+        return 0;
+    }
+
+    for _ in 0..(n + 1) {
+        c = a + b;
+        a = b;
+        b = c;
+    }
+    b
+}
+
+#[cfg(feature = "ctf")]
+#[criterion]
+fn compare_fibonaccis(c: &mut Criterion) {
+    let fib_slow = Fun::new("Recursive", |b, i| b.iter(|| fibonacci_slow(*i)));
+    let fib_fast = Fun::new("Iterative", |b, i| b.iter(|| fibonacci_fast(*i)));
+
+    let functions = vec![fib_slow, fib_fast];
+
+    c.bench_functions("Fibonacci", functions, 20);
+}


### PR DESCRIPTION
When the `--feature=ctf` is enabled, this PR exports a custom test runner and a `#[criterion]` proc macro from the `criterion` crate. This allows using criterion without the `criterion_group!` and `criterion_main!` macros by just using the `#[criterion]` proc macro instead (see `tests/ctf.rs` for a full example):

```rust
#[criterion]
fn compare_fibonaccis(c: &mut Criterion) {
    let fib_slow = Fun::new("Recursive", |b, i| b.iter(|| fibonacci_slow(*i)));
    let fib_fast = Fun::new("Iterative", |b, i| b.iter(|| fibonacci_fast(*i)));

    let functions = vec![fib_slow, fib_fast];

    c.bench_functions("Fibonacci", functions, 20);
}
```

Currently, each function marked with the `#[criterion]` attribute becomes its own benchmark group, but we might want to improve this in the future, e.g., using modules to express benchmarks groups, and functions to express benchmarks, like:

```rust
#[criterion_group]
mod fibonacci {
    #[criterion_benchmark]
    fn slow(c: &mut Criterion) { ... }

    #[criterion_benchmark]
    fn fast(c: &mut Criterion) { ... }
}
```

Closes #205 .