### PR TITLE
Fix iter_with_* overhead

### DIFF
--- a/benches/benchmarks/iter_with_large_drop.rs
+++ b/benches/benchmarks/iter_with_large_drop.rs
@@ -5,14 +5,31 @@ use std::time::Duration;
 
 const SIZE: usize = 1024 * 1024;
 
-fn alloc(c: &mut Criterion) {
+fn large_drop(c: &mut Criterion) {
     c.bench(
-        "alloc",
-        Benchmark::new("alloc", |b| {
-            b.iter_with_large_drop(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>())
-        }).warm_up_time(Duration::new(1, 0))
-            .throughput(Throughput::Bytes(SIZE as u32)),
+        "iter_with_large_drop",
+        Benchmark::new("large_drop", |b| {
+            let v: Vec<_> = (0..SIZE).map(|i| i as u8).collect();
+            b.iter_with_large_drop(|| v.clone());
+        }).throughput(Throughput::Bytes(SIZE as u32)),
     );
 }
 
-criterion_group!{benches, alloc}
+fn small_drop(c: &mut Criterion) {
+    c.bench(
+        "iter_with_large_drop",
+        Benchmark::new("small_drop", |b| {
+            b.iter_with_large_drop(|| SIZE);
+        }),
+    );
+}
+
+fn short_warmup() -> Criterion {
+    Criterion::default().warm_up_time(Duration::new(1, 0))
+}
+
+criterion_group!{
+    name = benches;
+    config = short_warmup();
+    targets = large_drop, small_drop
+}

--- a/benches/benchmarks/iter_with_large_setup.rs
+++ b/benches/benchmarks/iter_with_large_setup.rs
@@ -1,14 +1,26 @@
-use std::mem;
-
+use criterion::Benchmark;
 use criterion::Criterion;
+use criterion::Throughput;
 use std::time::Duration;
 
 const SIZE: usize = 1024 * 1024;
 
-fn dealloc(c: &mut Criterion) {
-    c.bench_function("large_dealloc", |b| {
-        b.iter_with_large_setup(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>(), mem::drop);
-    });
+fn large_setup(c: &mut Criterion) {
+    c.bench(
+        "iter_with_large_setup",
+        Benchmark::new("large_setup", |b| {
+            b.iter_with_large_setup(|| (0..SIZE).map(|i| i as u8).collect::<Vec<_>>(), |v| v.clone())
+        }).throughput(Throughput::Bytes(SIZE as u32)),
+    );
+}
+
+fn small_setup(c: &mut Criterion) {
+    c.bench(
+        "iter_with_large_setup",
+        Benchmark::new("small_setup", |b| {
+            b.iter_with_large_setup(|| SIZE, |size| size)
+        })
+    );
 }
 
 fn short_warmup() -> Criterion {
@@ -18,5 +30,5 @@ fn short_warmup() -> Criterion {
 criterion_group!{
     name = benches;
     config = short_warmup();
-    targets = dealloc
+    targets = large_setup, small_setup
 }

--- a/benches/benchmarks/iter_with_setup.rs
+++ b/benches/benchmarks/iter_with_setup.rs
@@ -1,13 +1,11 @@
-use std::mem;
-
 use criterion::Criterion;
 
 const SIZE: usize = 1024 * 1024;
 
-fn dealloc(c: &mut Criterion) {
-    c.bench_function("dealloc", |b| {
-        b.iter_with_setup(|| (0..SIZE).map(|_| 0u8).collect::<Vec<_>>(), mem::drop)
+fn setup(c: &mut Criterion) {
+    c.bench_function("iter_with_setup", |b| {
+        b.iter_with_setup(|| (0..SIZE).map(|i| i as u8).collect::<Vec<_>>(), |v| v.clone())
     });
 }
 
-criterion_group!(benches, dealloc);
+criterion_group!(benches, setup);


### PR DESCRIPTION
- Enhance iter_with_* benchmarks  …
  - Make sure that allocation is not optimised to `calloc` (which Rust does for common zero-fill allocations).
  - Measure same action across these benchmarks with same benchmark configs for easier comparisons.
  - Rename benchmarks to corresponding methods for clarity.
  - Add counterparts with unnecessary iter_with_large_* calls to measure overhead of these functions.
- Reduce overhead from iter_with_* functions …
  - Remove `black_box` from the hot path where possible (it's necessary to prevent optimisations, but doesn't have to be part of the measurement, especially the expensive `black_box` fallback used on stable Rust).
  - Use `repeat_with` + `.collect` in `iter_with_large_drop` to avoid `.push` which has to check capacity etc. on each iteration, whereas `repeat_with` lets `Vec` allocate everything in place in a tight loop.

For `iter_with_large_drop` and `iter_with_large_setup` with not-really-large drops this brings 20% and 15% increase in performance correspondingly, bringing them on par with performance of regular `.iter`.

Fixes #210.