### PR TITLE
Use simplelog 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ license = "Apache-2.0/MIT"
 
 [dependencies]
 backtrace = "0.3.5" # required only for minimal-versions. brought in by failure.
-chrono = "0.4.6" # required only for minimal-versions. brought in by simplelog.
 criterion-plot = { path="plot", version="0.2.5", optional = true }
 criterion-stats = { path="stats", version="0.2.5" }
 failure = "0.1.2"
@@ -21,7 +20,7 @@ failure_derive = "0.1.1"
 itertools = "0.7"
 itertools-num = "0.1"
 log = "0.4"
-simplelog = "0.5.1"
+simplelog = "0.5.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0.75"


### PR DESCRIPTION
simplelog 0.5.3 has updated its dependencies to require at least
chrono 0.4.1, which does not transitively depends on num 0.1.0
anymore which would not compile.

The chrono dependency does not need to be specified any longer.