### PR TITLE
Fixes link to example html report

### DIFF
--- a/book/src/user_guide/html_report.md
+++ b/book/src/user_guide/html_report.md
@@ -2,4 +2,4 @@
 
 If [gnuplot](http://www.gnuplot.info/) is installed, Criterion.rs can generate an HTML report displaying the results of the benchmark under `target/criterion/$BENCHMARK_NAME/`.
 
-To see an example report, [click here](user_guide/html_report/index.html). For more details on the charts and statistics displayed, check the other pages of this book.
+To see an example report, [click here](html_report/index.html). For more details on the charts and statistics displayed, check the other pages of this book.


### PR DESCRIPTION
See [here](https://japaric.github.io/criterion.rs/book/user_guide/html_report.html) - the relative link doesn't need `user_guide/`