### PR TITLE
When gnuplot --version errors, don't panic when parsing an empty stdout

### DIFF
--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -14,6 +14,8 @@ license = "MIT/Apache-2.0"
 byteorder = "1"
 cast = "0.2"
 itertools = "0.7"
+failure = "0.1.2"
+failure_derive = "0.1.1"
 
 [dev-dependencies]
 itertools-num = "0.1"

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -982,7 +982,6 @@ pub fn version() -> Result<(usize, usize, usize), Error> {
     if !command_output.status.success() {
         let error = String::from_utf8(command_output.stderr)
             .map_err(|_| VersionError::OutputError)?;
-        eprintln!("`gnuplot --version` returned an error\n{}", error);
         return Err(VersionError::Error(error).into());
     }
 

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -952,8 +952,13 @@ impl Plot {
 /// Returns `gnuplot` version
 // FIXME Parsing may fail
 pub fn version() -> io::Result<(usize, usize, usize)> {
-    let stdout = try!(Command::new("gnuplot").arg("--version").output()).stdout;
-    let mut words = str::from_utf8(&stdout).unwrap().split_whitespace().skip(1);
+    let command_output = try!(Command::new("gnuplot").arg("--version").output());
+    if !command_output.status.success() {
+        let error = str::from_utf8(&command_output.stderr).unwrap();
+        eprintln!("`gnuplot --version` returned an error\n{}", error);
+        return Err(io::Error::new(io::ErrorKind::Other, error));
+    }
+    let mut words = str::from_utf8(&command_output.stdout).unwrap().split_whitespace().skip(1);
     let mut version = words.next().unwrap().split('.');
     let major = version.next().unwrap().parse().unwrap();
     let minor = version.next().unwrap().parse().unwrap();

--- a/plot/src/lib.rs
+++ b/plot/src/lib.rs
@@ -401,12 +401,18 @@ extern crate cast;
 #[macro_use]
 extern crate itertools;
 
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+
 use std::borrow::Cow;
 use std::fs::File;
 use std::io;
 use std::path::Path;
 use std::process::{Child, Command};
 use std::str;
+
+use failure::Error;
 
 use data::Matrix;
 use traits::{Configure, Set};
@@ -949,20 +955,47 @@ impl Plot {
         &self.script
     }
 }
+
+/// Possible errors when parsing gnuplot's version string
+#[derive(Debug, Fail)]
+pub enum VersionError {
+    /// The `gnuplot` command couldn't be executed
+    #[fail(display = "`gnuplot --version` failed: {}", _0)]
+    Exec(#[cause] io::Error),
+    /// The `gnuplot` command returned an error message
+    #[fail(display = "`gnuplot --version` failed with error message:\n{}", _0)]
+    Error(String),
+    /// The `gnuplot` command returned invalid utf-8
+    #[fail(display = "`gnuplot --version` returned invalid utf-8")]
+    OutputError,
+    /// The `gnuplot` command returned an unparseable string
+    #[fail(display = "`gnuplot --version` returned an unparseable version string: {}", _0)]
+    ParseError(String),
+}
+
 /// Returns `gnuplot` version
-// FIXME Parsing may fail
-pub fn version() -> io::Result<(usize, usize, usize)> {
-    let command_output = try!(Command::new("gnuplot").arg("--version").output());
+pub fn version() -> Result<(usize, usize, usize), Error> {
+    use std::num::ParseIntError;
+
+    let command_output = Command::new("gnuplot").arg("--version").output()
+        .map_err(VersionError::Exec)?;
     if !command_output.status.success() {
-        let error = str::from_utf8(&command_output.stderr).unwrap();
+        let error = String::from_utf8(command_output.stderr)
+            .map_err(|_| VersionError::OutputError)?;
         eprintln!("`gnuplot --version` returned an error\n{}", error);
-        return Err(io::Error::new(io::ErrorKind::Other, error));
+        return Err(VersionError::Error(error).into());
     }
-    let mut words = str::from_utf8(&command_output.stdout).unwrap().split_whitespace().skip(1);
-    let mut version = words.next().unwrap().split('.');
-    let major = version.next().unwrap().parse().unwrap();
-    let minor = version.next().unwrap().parse().unwrap();
-    let patchlevel = words.nth(1).unwrap().parse().unwrap();
+
+    let output = String::from_utf8(command_output.stdout)
+        .map_err(|_| VersionError::OutputError)?;
+    let unwrap_none = || { VersionError::ParseError(output.clone()) };
+    let unwrap_err = |_: ParseIntError| { VersionError::ParseError(output.clone()) };
+
+    let mut words = output.split_whitespace().skip(1);
+    let mut version = words.next().ok_or_else(unwrap_none)?.split('.');
+    let major = version.next().ok_or_else(unwrap_none)?.parse().map_err(unwrap_err)?;
+    let minor = version.next().ok_or_else(unwrap_none)?.parse().map_err(unwrap_err)?;
+    let patchlevel = words.nth(1).ok_or_else(unwrap_none)?.parse().map_err(unwrap_err)?;
 
     Ok((major, minor, patchlevel))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,12 +532,17 @@ impl Default for Criterion {
 
         #[cfg(feature = "html_reports")]
         {
-            plotting = if criterion_plot::version().is_ok() {
-                Plotting::Enabled
-            } else {
-                println!("Gnuplot not found, disabling plotting");
-
-                Plotting::NotAvailable
+            use criterion_plot::VersionError;
+            plotting = match criterion_plot::version() {
+                Ok(_) => Plotting::Enabled,
+                Err(e) => {
+                    match e.downcast::<VersionError>() {
+                        Ok(VersionError::Exec(_)) => println!("Gnuplot not found, disabling plotting"),
+                        Ok(e) => println!("Gnuplot not found or not usable, disabling plotting\n{}", e),
+                        Err(_) => println!("Gnuplot not found or not usable, disabling plotting"),
+                    }
+                    Plotting::NotAvailable
+                },
             };
             reports.push(Box::new(Html::new()));
         }


### PR DESCRIPTION
There's an open `FIXME: Parsing may fail` comment in `plot::version()` which this PR partially addresses.

In the panic that I encountered, `gnuplot --version` failed completely (on OSX, it was linked to a version of a dylib that was no longer present on the system). The command printed its error message to stderr, leaving nothing in stdout for the function to parse.

The main issue that prompted this PR was that the panic on unwrapping a `None` gave no indication of what caused it, and I needed to search through the source on GitHub to find enough clues to work around.

This PR leaves the rest of the `unwrap`s untouched, but I could change those into descriptive `expect`s or wrap them in a `try!` like the intial command is, depending on what the intended behavior is.