### PR TITLE
Remove drop from timed loop in `iter_with_large_setup`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,11 +456,14 @@ impl Bencher {
         self.iterated = true;
         let inputs = black_box(repeat_with(setup).take(self.iters as _).collect::<Vec<_>>());
 
-        let start = Instant::now();
+        self.elapsed = Duration::from_secs(0);
         for input in inputs {
-            black_box(routine(input));
+            let start = Instant::now();
+            let output = routine(input);
+            self.elapsed += start.elapsed();
+
+            drop(black_box(output));
         }
-        self.elapsed = start.elapsed();
     }
 
     // Benchmarks must actually call one of the iter methods. This causes benchmarks to fail loudly


### PR DESCRIPTION
I found the behavior of the `iter_with_setup` method very useful
because it allows returning values with significant drop times
to exclude it from the benchmark.

The `iter_with_large_setup` method currently does not follow the
same procedure as the normal `iter_with_setup` method, so this
is a proposal to streamline the two methods and make it possible
to drop things outside of the timed scope.