### PR TITLE
Update failure_derive to 0.1.2 to match failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ backtrace = "0.3.5" # required only for minimal-versions. brought in by failure.
 criterion-plot = { path="plot", version="0.2.5", optional = true }
 criterion-stats = { path="stats", version="0.2.5" }
 failure = "0.1.2"
-failure_derive = "0.1.1"
+failure_derive = "0.1.2"
 itertools = "0.7"
 itertools-num = "0.1"
 log = "0.4"

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1"
 cast = "0.2"
 itertools = "0.7"
 failure = "0.1.2"
-failure_derive = "0.1.1"
+failure_derive = "0.1.2"
 
 [dev-dependencies]
 itertools-num = "0.1"


### PR DESCRIPTION
Fixes compiler errors on `master`:
```
error: failed to select a version for `failure_derive`.
    ... required by package `failure v0.1.2`
    ... which is depended on by `criterion v0.2.5 (https://github.com/japaric/criterion.rs?rev=edf6f9d9719165c29cb5e06f1be9aafa97e69867#edf6f9d9)`

versions that meet the requirements `^0.1.2` are: 0.1.3, 0.1.2

all possible versions conflict with previously selected packages.

  previously selected package `failure_derive v0.1.1`
    ... which is depended on by `criterion v0.2.5 (https://github.com/japaric/criterion.rs?rev=edf6f9d9719165c29cb5e06f1be9aafa97e69867#edf6f9d9)`
```