### PR TITLE
Set handlebars version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0"
 serde_derive = "1.0.75"
 atty = "0.2.5"
 clap = "2.29"
-handlebars = { version="1.0.3", optional = true }
+handlebars = { version="~1.0.3", optional = true }
 csv = "1.0"
 walkdir = "2.2.3"
 


### PR DESCRIPTION
Keeping handlebars version in 1.0.x range for rust 1.23.0 support. I'm going to merge Pest 2.0 in Handlebars 1.1.0, which doesn't work with Rust 1.23.