### PR TITLE
Update the dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ license = "Apache-2.0/MIT"
 backtrace = "0.3.5" # required only for minimal-versions. brought in by failure.
 criterion-plot = { path="plot", version="0.2.5", optional = true }
 criterion-stats = { path="stats", version="0.2.5" }
-failure = "0.1.2"
-failure_derive = "0.1.2"
+failure = "0.1.3"
+failure_derive = "0.1.3"
 itertools = "0.7"
 itertools-num = "0.1"
 log = "0.4"
@@ -26,7 +26,7 @@ serde_json = "1.0"
 serde_derive = "1.0.75"
 atty = "0.2.5"
 clap = "2.29"
-handlebars = { version="~1.0.3", optional = true }
+handlebars = { version="~1.1.0", optional = true }
 csv = "1.0"
 walkdir = "2.2.3"
 

--- a/plot/Cargo.toml
+++ b/plot/Cargo.toml
@@ -14,12 +14,12 @@ license = "MIT/Apache-2.0"
 byteorder = "1"
 cast = "0.2"
 itertools = "0.7"
-failure = "0.1.2"
-failure_derive = "0.1.2"
+failure = "0.1.3"
+failure_derive = "0.1.3"
 
 [dev-dependencies]
 itertools-num = "0.1"
-num-complex = { version = "0.1", default-features = false }
+num-complex = { version = "0.2", default-features = false }
 rand = "0.4"
 
 [badges]

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.4"
 thread-scoped = "1.0.2"
 
 [dev-dependencies]
-approx = "0.1.1"
+approx = "0.3"
 itertools-num = "0.1"
 quickcheck = { version = "0.7", default-features = false }
 criterion = { path="..", version="0.2.1", default-features = false }


### PR DESCRIPTION
It is mainly needed for the `failure` dep, I will send another patch later to update `rand` since it requires code changes.

Currently criterion tests pass on stable but do not build on nightly even before this update.